### PR TITLE
Fixed mode error, added Temperature units.

### DIFF
--- a/HoneywellThermo-TCC_C.groovy
+++ b/HoneywellThermo-TCC_C.groovy
@@ -71,7 +71,7 @@ metadata {
         attribute  "followSchedule",     "string"
         attribute  "DriverStatus",       "string"
         attribute  "DriverUpdate",       "string"
-        attribute  "ThermostatOperatingState", "string"
+        attribute  "thermostatOperatingState", "string"
 
 //	  command "updateCheck"			// **---** delete for Release
     }
@@ -496,15 +496,15 @@ def getStatusHandler(resp, data) {
 		def fanState = "Unknown"
 		
 		if (fanIsRunning == true) {
-		    fanState = "On";
+		    fanState = "on";
 		    if (mode == "heat") {
 		        operatingState = "heating"
 		    } else {
 		        operatingState = "cooling"
 		    }
 		} else {
-		    fanState = "Idle";
-		    operatingState = "Idle"
+		    fanState = "idle";
+		    operatingState = "idle"
 		}
 		
 		logInfo("Set Operating State to: ${operatingState}")

--- a/HoneywellThermo-TCC_C.groovy
+++ b/HoneywellThermo-TCC_C.groovy
@@ -13,7 +13,7 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
- *
+ *        : v1.3.4   added "°F" or "°C" unit to temp and setpoint events. Fixed thermostateMode being set to a temperature value.
  * csteele: v1.3.2   centralized Honeywell site url as "tccSite"
  * csteele: v1.3.1   updated to v2 of updateCheck
  * csteele: v1.3.0   converted to asynchttp where posssible.
@@ -49,7 +49,7 @@
  *
 */
 
- public static String version()     {  return "v1.3.3"  }
+ public static String version()     {  return "v1.3.4"  }
  public static String tccSite() 	{  return "www.mytotalconnectcomfort.com"  }
 
 metadata {
@@ -196,10 +196,11 @@ def setHeatingSetpoint(Double temp)
 	deviceDataInit(state.PermHold)
 	device.data.HeatSetpoint = temp
 	setStatus()
-
+    def unit = "°${location.temperatureScale}"
+	
 	if(device.data.SetStatus==1)
 	{
-      	sendEvent(name: 'heatingSetpoint', value: temp as double)
+      	sendEvent(name: 'heatingSetpoint', value: temp as double, unit: unit)
 	}	
 }
 
@@ -207,10 +208,11 @@ def setHeatingSetpoint(temp) {
 	deviceDataInit(state.PermHold)
 	device.data.HeatSetpoint = temp
 	setStatus()
+    def unit = "°${location.temperatureScale}"
 	
 	if(device.data.SetStatus==1)
 	{
-	    sendEvent(name: 'heatingSetpoint', value: temp as Integer)
+	    sendEvent(name: 'heatingSetpoint', value: temp as Integer, unit:unit)
 	}
 }
 
@@ -232,10 +234,11 @@ def setCoolingSetpoint(double temp) {
 	deviceDataInit(state.PermHold)
 	device.data.CoolSetpoint = temp
 	setStatus()
-
+    def unit = "°${location.temperatureScale}"
+	
 	if(device.data.SetStatus==1)
 	{
-	    sendEvent(name: 'coolingSetpoint', value: temp as double)
+	    sendEvent(name: 'coolingSetpoint', value: temp as double, unit:unit)
 	}
 }
 
@@ -243,10 +246,11 @@ def setCoolingSetpoint(temp) {
 	deviceDataInit(state.PermHold)
 	device.data.CoolSetpoint = temp
 	setStatus()
-
+    def unit = "°${location.temperatureScale}"
+	
 	if(device.data.SetStatus==1)
 	{
-	    sendEvent(name: 'coolingSetpoint', value: temp as Integer)
+	    sendEvent(name: 'coolingSetpoint', value: temp as Integer, unit:unit)
 	}
 }
 
@@ -450,6 +454,12 @@ def getStatusHandler(resp, data) {
 		def equipmentStatus = setStatusResult.latestData.uiData.EquipmentOutputStatus	
 		def holdTime = setStatusResult.latestData.uiData.TemporaryHoldUntilTime
 		def vacationHold = setStatusResult.latestData.uiData.IsInVacationHoldMode
+	
+		// Add code to enforce the thermostat limits - not done yet!
+		def heatLowerSetptLimit = setStatusResult.latestData.uiData.HeatLowerSetptLimit 
+		def heatUpperSetptLimit = setStatusResult.latestData.uiData.HeatUpperSetptLimit 
+		def coolLowerSetptLimit = setStatusResult.latestData.uiData.CoolLowerSetptLimit 
+		def coolUpperSetptLimit = setStatusResult.latestData.uiData.CoolUpperSetptLimit 
 		
 		def fanMode = setStatusResult.latestData.fanData.fanMode
 		def fanIsRunning = setStatusResult.latestData.fanData.fanIsRunning
@@ -512,23 +522,25 @@ def getStatusHandler(resp, data) {
 				sendEvent(name: 'thermostatFanMode', value: 'circulate');
 				break;
 		}
+		
+		def unit = "°${location.temperatureScale}"
 	
 		switch(switchPos) {
 			case 1:
-				sendEvent(name: 'temperature', value: curTemp, state: 'on');
-				sendEvent(name: 'thermostatMode', value: curTemp, state: 'on');
+				sendEvent(name: 'temperature', value: curTemp, state: 'heat', unit:unit);
+				sendEvent(name: 'thermostatMode', value: 'heat');
 				break;
 			case 2:
-				sendEvent(name: 'temperature', value: curTemp, state: 'off');
-				sendEvent(name: 'thermostatMode', value: curTemp, state: 'off');
+				sendEvent(name: 'temperature', value: curTemp, state: 'off', unit:unit);
+				sendEvent(name: 'thermostatMode', value: 'off');
 				break;
 			case 3:
-				sendEvent(name: 'temperature', value: curTemp, state: 'cool');
-				sendEvent(name: 'thermostatMode', value: curTemp, state: 'cool');
+				sendEvent(name: 'temperature', value: curTemp, state: 'cool', unit:unit);
+				sendEvent(name: 'thermostatMode', value: 'cool');
 				break;
 			default:
-				sendEvent(name: 'temperature', value: curTemp, state: 'auto');
-				sendEvent(name: 'thermostatMode', value: curTemp, state: 'auto');
+				sendEvent(name: 'temperature', value: curTemp, state: 'auto', unit:unit);
+				sendEvent(name: 'thermostatMode', value: 'auto');
 				break;
 		}
 		
@@ -537,9 +549,9 @@ def getStatusHandler(resp, data) {
 		sendEvent(name: 'fanOperatingState', value: fanState)
 //		sendEvent(name: 'thermostatFanMode', value: fanMode)
 //		sendEvent(name: 'thermostatMode', value: switchPos)
-		sendEvent(name: 'coolingSetpoint', value: coolSetPoint)
-		sendEvent(name: 'heatingSetpoint', value: heatSetPoint)
-//		sendEvent(name: 'temperature', value: curTemp, state: switchPos)
+		sendEvent(name: 'coolingSetpoint', value: coolSetPoint, unit:unit)
+		sendEvent(name: 'heatingSetpoint', value: heatSetPoint, unit:unit)
+//		sendEvent(name: 'temperature', value: curTemp, state: switchPos, unit:unit)
 		sendEvent(name: 'relativeHumidity', value: curHumidity as Integer)
 		
 		def now = new Date().format('MM/dd/yyyy h:mm a', location.timeZone)
@@ -553,7 +565,7 @@ def getStatusHandler(resp, data) {
 		    }
 		
 		    if (hasOutdoorTemp) {
-		        sendEvent(name: 'outdoorTemperature', value: curOutdoorTemp as Integer)
+		        sendEvent(name: 'outdoorTemperature', value: curOutdoorTemp as Integer, unit:unit)
 		    }
 		}
 	} else { if (descTextEnable) log.info "TCC getStatus failed" }


### PR DESCRIPTION
Added "unit" variable with values "°F" or "°C" unit to temperature reporting and setpoint sendEvents.

Fixed 'thermostatMode" sendEvents at lines 529-545. Previously, they were initially being set to a temperature value, not the mode value.

Also added some defined variables for the minimum and maximum heating / cooling setpoints. See lines 459-462. They aren't used yet, but it would be great if someone more knowledgeable about the code could use these to range-check the up/down heating/cooling actions as well as any other heating/cooling setpoint change and enforce the ranges / log an error if a user tries to exceed them.